### PR TITLE
Bugfixing relation

### DIFF
--- a/bundle/Form/FieldTypeHandler/Relation.php
+++ b/bundle/Form/FieldTypeHandler/Relation.php
@@ -71,6 +71,6 @@ class Relation extends FieldTypeHandler
             return null;
         }
 
-        return $this->repository->getContentService()->loadContent($value->destinationContentId);
+        return $value->destinationContentId;
     }
 }


### PR DESCRIPTION
in the ContentUpdate Mode when having an Object Relation and a location is already selected for that objectRelation, we get currently get an error saying: 
"  Catchable Fatal Error: Object of class eZ\Publish\Core\Repository\Values\Content\Content could not be converted to string "
and it is because the "eZ\Publish\Core\Repository\Values\Content\Content" Class does not have a __toString method.

This workaround solved the problem for me. you can merge it if you feel this can be a general solution for all